### PR TITLE
fix: cors middleware

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -1,4 +1,6 @@
 NEXT_PUBLIC_APP_FQDN=localhost:3000
+# Comma-separated list of allowed origins for CORS (e.g., "https://example.com,https://app.example.com")
+ALLOWED_ORIGINS=https://www.mockfedcm.ory.sh,https://mockfedcm.ory.sh
 JWT_SECRET=your-secret-key-change-in-production
 FEDCM_PROVIDER_NAME=Mock FedCM IdP
 FEDCM_BACKGROUND_COLOR=#ffffff

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,13 @@
-import type { NextConfig } from 'next';
+import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   experimental: {
     serverActions: {
       allowedOrigins:
-        process.env.NODE_ENV === 'production'
-          ? [process.env.NEXT_PUBLIC_APP_FQDN || '']
-          : ['*'],
-      bodySizeLimit: '2mb',
+        process.env.NODE_ENV === "production"
+          ? [process.env.NEXT_PUBLIC_APP_FQDN || ""]
+          : ["*"],
+      bodySizeLimit: "2mb",
     },
   },
   typescript: {
@@ -17,41 +17,63 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: false,
   },
   allowedDevOrigins:
-    process.env.NODE_ENV === 'production'
-      ? [process.env.NEXT_PUBLIC_APP_FQDN || '']
-      : ['localhost'],
+    process.env.NODE_ENV === "production"
+      ? [process.env.NEXT_PUBLIC_APP_FQDN || ""]
+      : ["localhost"],
   async headers() {
     return [
       {
-        source: '/:path*',
+        source: "/:path*",
         headers: [
           {
-            key: 'X-DNS-Prefetch-Control',
-            value: 'on',
+            key: "X-DNS-Prefetch-Control",
+            value: "on",
           },
           {
-            key: 'Strict-Transport-Security',
-            value: 'max-age=63072000; includeSubDomains; preload',
+            key: "Strict-Transport-Security",
+            value: "max-age=63072000; includeSubDomains; preload",
           },
           {
-            key: 'X-XSS-Protection',
-            value: '1; mode=block',
+            key: "X-XSS-Protection",
+            value: "1; mode=block",
           },
           {
-            key: 'X-Frame-Options',
-            value: 'SAMEORIGIN',
+            key: "X-Frame-Options",
+            value: "SAMEORIGIN",
           },
           {
-            key: 'X-Content-Type-Options',
-            value: 'nosniff',
+            key: "X-Content-Type-Options",
+            value: "nosniff",
           },
           {
-            key: 'Referrer-Policy',
-            value: 'origin-when-cross-origin',
+            key: "Referrer-Policy",
+            value: "origin-when-cross-origin",
           },
           {
-            key: 'Permissions-Policy',
-            value: 'camera=(), microphone=(), geolocation=()',
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=()",
+          },
+        ],
+      },
+      {
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Access-Control-Allow-Credentials",
+            value: "true",
+          },
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "*",
+          },
+          {
+            key: "Access-Control-Allow-Methods",
+            value: "GET,OPTIONS,PATCH,DELETE,POST,PUT",
+          },
+          {
+            key: "Access-Control-Allow-Headers",
+            value:
+              "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version",
           },
         ],
       },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const origin = request.headers.get("origin") || "";
+  const isApiRoute = request.nextUrl.pathname.startsWith("/api/");
+
+  // Parse allowed origins from environment variable
+  const allowedOrigins =
+    process.env.NODE_ENV === "production"
+      ? (process.env.ALLOWED_ORIGINS || process.env.NEXT_PUBLIC_APP_FQDN || "")
+          .split(",")
+          .map((o) => o.trim())
+      : ["http://localhost:3000", "https://localhost:3000"];
+
+  // Handle preflight requests
+  if (request.method === "OPTIONS") {
+    return new NextResponse(null, {
+      status: 204,
+      headers: {
+        "Access-Control-Allow-Origin": isApiRoute
+          ? "*"
+          : allowedOrigins.includes(origin)
+            ? origin
+            : "",
+        "Access-Control-Allow-Methods":
+          "GET, POST, PUT, DELETE, OPTIONS, PATCH",
+        "Access-Control-Allow-Headers":
+          "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version",
+        "Access-Control-Max-Age": "86400",
+        Vary: "Origin",
+      },
+    });
+  }
+
+  // Handle actual requests
+  const response = NextResponse.next();
+
+  // Add CORS headers to all responses
+  response.headers.set(
+    "Access-Control-Allow-Origin",
+    isApiRoute ? "*" : allowedOrigins.includes(origin) ? origin : ""
+  );
+  response.headers.set(
+    "Access-Control-Allow-Methods",
+    "GET, POST, PUT, DELETE, OPTIONS, PATCH"
+  );
+  response.headers.set(
+    "Access-Control-Allow-Headers",
+    "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version"
+  );
+  response.headers.set("Vary", "Origin");
+
+  return response;
+}
+
+// Configure which routes to run middleware on
+export const config = {
+  matcher: [
+    // Match all API routes
+    "/api/:path*",
+    // Match the specific FedCM config endpoint
+    "/api/fedcm/config.json",
+    // Match all other routes
+    "/:path*",
+  ],
+};


### PR DESCRIPTION
Had to add CORS middleware as vercel doesn't look at the nextjs config for header information. This should keep the /api/ path open with any origin but make sure the paths are otherwise locked down. it will require another env variable that can take an array (comma separated string) of urls for allowed origins. This will let us cover the migration case to mockfedcm.com in the future as well with a simple update of the env. 